### PR TITLE
Implemented babel-plugin-transform-react-remove-prop-types

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,12 @@
   "presets": ["es2015", "react", "stage-1"],
   "plugins": [
     "react-hot-loader/babel"
-  ]
+  ],
+  "env": {
+    "production": {
+      "plugins": [
+        "transform-react-remove-prop-types"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-eslint": "^7.0.0",
     "babel-jest": "^17.0.2",
     "babel-loader": "^6.2.5",
+    "babel-plugin-transform-react-remove-prop-types": "^0.2.11",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-1": "^6.16.0",


### PR DESCRIPTION
See #14

It removed 55 proptype declarations from the example site. It saved 1 Kb (416Kb -> 415Kb).

I don't think it will have a big impact after gziping the file.