### PR TITLE
Make it possible to set publicPath on build

### DIFF
--- a/src-clean/index.js
+++ b/src-clean/index.js
@@ -1,15 +1,17 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { AppContainer } from 'react-hot-loader'
-import { Router, browserHistory } from 'react-router'
+import { createHistory } from 'history'
+import { Router, useRouterHistory } from 'react-router'
 
 import routes from 'routes'
 
 const root = document.getElementById('app')
+const history = useRouterHistory(createHistory)({ basename: process.env.PUBLIC_PATH })
 
 const renderApp = () => (
   <AppContainer>
-    <Router history={browserHistory} routes={routes} />
+    <Router history={history} routes={routes} />
   </AppContainer>
 )
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,17 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { AppContainer } from 'react-hot-loader'
-import { Router, browserHistory } from 'react-router'
+import { createHistory } from 'history'
+import { Router, useRouterHistory } from 'react-router'
 
 import routes from 'routes'
 
 const root = document.getElementById('app')
+const history = useRouterHistory(createHistory)({ basename: process.env.PUBLIC_PATH })
 
 const renderApp = () => (
   <AppContainer>
-    <Router history={browserHistory} routes={routes} />
+    <Router history={history} routes={routes} />
   </AppContainer>
 )
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ip = process.env.IP || '0.0.0.0'
 const port = process.env.PORT || 3000
 const DEBUG = process.env.NODE_ENV !== 'production'
+const PUBLIC_PATH = `/${process.env.PUBLIC_PATH || ''}/`.replace('//', '/')
 
 const config = {
   devtool: DEBUG ? 'eval' : false,
@@ -14,14 +15,15 @@ const config = {
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'app.[hash].js',
-    publicPath: '/'
+    publicPath: PUBLIC_PATH
   },
   resolve: {
-    modules: ['src', 'node_modules'],
+    modules: ['src', 'node_modules']
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': `'${process.env.NODE_ENV}'`
+      'process.env.NODE_ENV': `'${process.env.NODE_ENV}'`,
+      'process.env.PUBLIC_PATH': `'${PUBLIC_PATH}'`
     }),
     new HtmlWebpackPlugin({
       filename: 'index.html',
@@ -35,7 +37,7 @@ const config = {
       { test: /\.jpg$/, loader: 'url-loader?prefix=images/&limit=8000&mimetype=image/jpeg' },
       { test: /\.woff$/, loader: 'url-loader?prefix=fonts/&limit=8000&mimetype=application/font-woff' },
       { test: /\.ttf$/, loader: 'file-loader?prefix=fonts/' },
-      { test: /\.eot$/, loader: 'file-loader?prefix=fonts/' },
+      { test: /\.eot$/, loader: 'file-loader?prefix=fonts/' }
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,6 +244,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.3.0.tgz#cb8a9984e2862711c83c80ade5b8f5ca0de2b467"
+  dependencies:
+    ast-types-flow "0.0.7"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -331,6 +337,10 @@ assert@^1.1.1:
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
     util "0.10.3"
+
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
 ast-types@0.9.5:
   version "0.9.5"
@@ -2284,6 +2294,10 @@ elliptic@^6.0.0:
     hash.js "^1.0.0"
     inherits "^2.0.1"
 
+emoji-regex@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.0.tgz#d14ef743a7dfa6eaf436882bd1920a4aed84dd94"
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -2512,11 +2526,14 @@ eslint-plugin-import@^2.2.0:
     minimatch "^3.0.3"
     pkg-up "^1.0.0"
 
-eslint-plugin-jsx-a11y@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-3.0.2.tgz#9f0eabcafde3d2a2600d96a66adb90d099e841fe"
+eslint-plugin-jsx-a11y@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-4.0.0.tgz#779bb0fe7b08da564a422624911de10061e048ee"
   dependencies:
+    aria-query "^0.3.0"
+    ast-types-flow "0.0.7"
     damerau-levenshtein "^1.0.0"
+    emoji-regex "^6.1.0"
     jsx-ast-utils "^1.0.0"
     object-assign "^4.0.1"
 


### PR DESCRIPTION
This PR adds the possibility to set the `webpack publicPath config` and `react-router basename` on build by just running  `PUBLIC_PATH=foo npm run build`.

This is necessary to run the project on URLs like https://diegohaz.github.io/foo