### PR TITLE
mark *.lock files as binary for ease of merging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lock binary


### PR DESCRIPTION
Separate PR as discussed in #101 