### PR TITLE
Adding a custom babelrc to be used by the storybook, this FIX #147

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    "latest",
+    "react",
+    "stage-1",
+  ]
+}


### PR DESCRIPTION
As the main `.babelrc` configuration is now disabling es6 modules transpilation to take advantage of webpack 2 Tree Shaking we need a custom `.babelrc` file to be used in storybook as they'll still need the modules transpilation.