### PR TITLE
Prevent containers from being processed and exported twice

### DIFF
--- a/src-clean/containers/index.js
+++ b/src-clean/containers/index.js
@@ -1,4 +1,4 @@
-const req = require.context('.', false, /^((?!index).)*$/)
+const req = require.context('.', false, /^((?!index).)*\.js$/)
 
 req.keys().forEach((key) => {
   const containerName = key.replace(/^\.\/([^.]+)\.js$/, '$1')

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -1,4 +1,4 @@
-const req = require.context('.', false, /^((?!index).)*$/)
+const req = require.context('.', false, /^((?!index).)*\.js$/)
 
 req.keys().forEach((key) => {
   const containerName = key.replace(/^\.\/([^.]+)\.js$/, '$1')


### PR DESCRIPTION
As a fix to #149 we need a stricter RegEx to avoid containers from being processed and consequently exported twice.