### PR TITLE
[master] Added functionality on forms for default props.  Currently a…

### DIFF
--- a/src/components/atoms/Input/index.js
+++ b/src/components/atoms/Input/index.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import styled, { css } from 'styled-components'
 import { font, palette } from 'styled-theme'
 import { ifProp } from 'styled-tools'
+import { omit } from 'lodash'
 
 export const fontSize = ({ height }) => `${height / 35.5555555556}rem`
 
@@ -34,12 +35,16 @@ const StyledSelect = styled.select`${styles}`
 const StyledInput = styled.input`${styles}`
 
 const Input = ({ ...props }) => {
+  const modifiedProps = 'defaultValue' in { ...props }
+    ? omit({ ...props }, 'value')
+    : { ...props }
+
   if (props.type === 'textarea') {
-    return <StyledTextarea {...props} />
+    return <StyledTextarea {...modifiedProps} />
   } else if (props.type === 'select') {
-    return <StyledSelect {...props} />
+    return <StyledSelect {...modifiedProps} />
   }
-  return <StyledInput {...props} />
+  return <StyledInput {...modifiedProps} />
 }
 
 Input.propTypes = {


### PR DESCRIPTION
…n error was being thrown if you added a default Prop

Here is there error that was being thrown: 
```js
Warning: styled.input contains an input of type text with both value and defaultValue props. 
Input elements must be either controlled or uncontrolled (specify either the value prop, or 
the defaultValue prop, but not both). Decide between using a controlled or uncontrolled 
input element and remove one of these props. More info: 
https://fb.me/react-controlled-components
```

I just immutably replaced `value` with `defaultValue` if `defaultValue` was specified by user.