### PR TITLE
[redux] Pass API instance down to sagas

### DIFF
--- a/src-example/config.js
+++ b/src-example/config.js
@@ -3,6 +3,8 @@ const merge = require('lodash/merge')
 const config = {
   all: {
     env: process.env.NODE_ENV || 'development',
+    isDev: process.env.NODE_ENV !== 'production',
+    isBrowser: typeof window !== 'undefined',
     apiUrl: 'https://jsonplaceholder.typicode.com',
     fbAppId: '991453140998882',
     googleClientId: '464712936089-q953apdu1bjiqtcjndktnnk1ts4f2cgv.apps.googleusercontent.com',

--- a/src-example/index.js
+++ b/src-example/index.js
@@ -7,11 +7,11 @@ import { createHistory } from 'history'
 import { Router, useRouterHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
 import configureStore from 'store/configure'
-
+import api from 'services/api'
 import routes from 'routes'
 
 const baseHistory = useRouterHistory(createHistory)({ basename: process.env.PUBLIC_PATH })
-const store = configureStore({}, baseHistory)
+const store = configureStore({}, baseHistory, { api: api.create() })
 const history = syncHistoryWithStore(baseHistory, store)
 const root = document.getElementById('app')
 

--- a/src-example/store/configure.js
+++ b/src-example/store/configure.js
@@ -1,21 +1,28 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import { routerMiddleware } from 'react-router-redux'
 import createSagaMiddleware from 'redux-saga'
+import { isDev, isBrowser } from 'config'
 import middlewares from './middlewares'
 import reducer from './reducer'
 import sagas from './sagas'
 
-const configureStore = (initialState, history) => {
-  const hasWindow = typeof window !== 'undefined'
-  const sagaMiddleware = createSagaMiddleware()
+const devtools = isDev && isBrowser && window.devToolsExtension
+  ? window.devToolsExtension
+  : () => fn => fn
+const sagaMiddleware = createSagaMiddleware()
 
-  const finalCreateStore = compose(
-    applyMiddleware(...middlewares, sagaMiddleware, routerMiddleware(history)),
-    hasWindow && window.devToolsExtension ? window.devToolsExtension() : (f) => f
-  )(createStore)
+const configureStore = (initialState, history, services = {}) => {
+  const enhancers = [
+    applyMiddleware(
+      ...middlewares,
+      sagaMiddleware,
+      routerMiddleware(history)
+    ),
+    devtools(),
+  ]
 
-  const store = finalCreateStore(reducer, initialState)
-  let sagaTask = sagaMiddleware.run(sagas)
+  const store = createStore(reducer, initialState, compose(...enhancers))
+  let sagaTask = sagaMiddleware.run(sagas, services)
 
   if (module.hot) {
     module.hot.accept('./reducer', () => {
@@ -26,7 +33,7 @@ const configureStore = (initialState, history) => {
       const nextSagas = require('./sagas').default
       sagaTask.cancel()
       sagaTask.done.then(() => {
-        sagaTask = sagaMiddleware.run(nextSagas)
+        sagaTask = sagaMiddleware.run(nextSagas, services)
       })
     })
   }

--- a/src-example/store/post/sagas.js
+++ b/src-example/store/post/sagas.js
@@ -1,40 +1,39 @@
 import { take, put, call, fork } from 'redux-saga/effects'
-import api from 'services/api'
 import * as actions from './actions'
 
-export function* createPost(newData) {
+export function* createPost(api, newData) {
   try {
-    const data = yield call(api.post, '/posts', newData)
+    const data = yield call([api, api.post], '/posts', newData)
     yield put(actions.postCreateSuccess(data))
   } catch (e) {
     yield put(actions.postCreateFailure(e))
   }
 }
 
-export function* readPostList(params) {
+export function* readPostList(api, params) {
   try {
-    const data = yield call(api.get, '/posts', { params })
+    const data = yield call([api, api.get], '/posts', { params })
     yield put(actions.postListReadSuccess(data))
   } catch (e) {
     yield put(actions.postListReadFailure(e))
   }
 }
 
-export function* watchPostCreateRequest() {
+export function* watchPostCreateRequest(api) {
   while (true) {
     const { data } = yield take(actions.POST_CREATE_REQUEST)
-    yield call(createPost, data)
+    yield call(createPost, api, data)
   }
 }
 
-export function* watchPostListReadRequest() {
+export function* watchPostListReadRequest(api) {
   while (true) {
     const { params } = yield take(actions.POST_LIST_READ_REQUEST)
-    yield call(readPostList, params)
+    yield call(readPostList, api, params)
   }
 }
 
-export default function* () {
-  yield fork(watchPostCreateRequest)
-  yield fork(watchPostListReadRequest)
+export default function* ({ api }) {
+  yield fork(watchPostCreateRequest, api)
+  yield fork(watchPostListReadRequest, api)
 }

--- a/src-example/store/post/sagas.test.js
+++ b/src-example/store/post/sagas.test.js
@@ -1,55 +1,73 @@
 import { take, put, call, fork } from 'redux-saga/effects'
-import api from 'services/api'
 import * as actions from './actions'
 import saga, * as sagas from './sagas'
+
+const api = {
+  post: () => {},
+  get: () => {},
+}
 
 describe('createPost', () => {
   const data = { title: 'test' }
 
   it('calls success', () => {
-    const generator = sagas.createPost(data)
-    expect(generator.next().value).toEqual(call(api.post, '/posts', data))
-    expect(generator.next(data).value).toEqual(put(actions.postCreateSuccess(data)))
+    const generator = sagas.createPost(api, data)
+    expect(generator.next().value)
+      .toEqual(call([api, api.post], '/posts', data))
+    expect(generator.next(data).value)
+      .toEqual(put(actions.postCreateSuccess(data)))
   })
 
   it('calls failure', () => {
-    const generator = sagas.createPost(data)
-    expect(generator.next().value).toEqual(call(api.post, '/posts', data))
-    expect(generator.throw('test').value).toEqual(put(actions.postCreateFailure('test')))
+    const generator = sagas.createPost(api, data)
+    expect(generator.next().value)
+      .toEqual(call([api, api.post], '/posts', data))
+    expect(generator.throw('test').value)
+      .toEqual(put(actions.postCreateFailure('test')))
   })
 })
 
 describe('readPostList', () => {
   it('calls success', () => {
     const data = [1, 2, 3]
-    const generator = sagas.readPostList({ _limit: 1 })
-    expect(generator.next().value).toEqual(call(api.get, '/posts', { params: { _limit: 1 } }))
-    expect(generator.next(data).value).toEqual(put(actions.postListReadSuccess(data)))
+    const generator = sagas.readPostList(api, { _limit: 1 })
+    expect(generator.next().value)
+      .toEqual(call([api, api.get], '/posts', { params: { _limit: 1 } }))
+    expect(generator.next(data).value)
+      .toEqual(put(actions.postListReadSuccess(data)))
   })
 
   it('calls failure', () => {
-    const generator = sagas.readPostList({ _limit: 1 })
-    expect(generator.next().value).toEqual(call(api.get, '/posts', { params: { _limit: 1 } }))
-    expect(generator.throw('test').value).toEqual(put(actions.postListReadFailure('test')))
+    const generator = sagas.readPostList(api, { _limit: 1 })
+    expect(generator.next().value)
+      .toEqual(call([api, api.get], '/posts', { params: { _limit: 1 } }))
+    expect(generator.throw('test').value)
+      .toEqual(put(actions.postListReadFailure('test')))
   })
 })
 
 test('watchPostCreateRequest', () => {
   const payload = { data: 1 }
-  const generator = sagas.watchPostCreateRequest()
-  expect(generator.next().value).toEqual(take(actions.POST_CREATE_REQUEST))
-  expect(generator.next(payload).value).toEqual(call(sagas.createPost, ...Object.values(payload)))
+  const generator = sagas.watchPostCreateRequest(api)
+  expect(generator.next().value)
+    .toEqual(take(actions.POST_CREATE_REQUEST))
+  expect(generator.next(payload).value)
+    .toEqual(call(sagas.createPost, api, ...Object.values(payload)))
 })
 
 test('watchPostListReadRequest', () => {
   const payload = { params: { _limit: 1 } }
-  const generator = sagas.watchPostListReadRequest()
-  expect(generator.next().value).toEqual(take(actions.POST_LIST_READ_REQUEST))
-  expect(generator.next(payload).value).toEqual(call(sagas.readPostList, ...Object.values(payload)))
+  const generator = sagas.watchPostListReadRequest(api)
+  expect(generator.next().value)
+    .toEqual(take(actions.POST_LIST_READ_REQUEST))
+  expect(generator.next(payload).value)
+    .toEqual(call(sagas.readPostList, api, ...Object.values(payload)))
 })
 
 test('saga', () => {
-  const generator = saga()
-  expect(generator.next().value).toEqual(fork(sagas.watchPostCreateRequest))
-  expect(generator.next().value).toEqual(fork(sagas.watchPostListReadRequest))
+  const generator = saga({ api })
+  expect(generator.next().value)
+    .toEqual(fork(sagas.watchPostCreateRequest, api))
+  expect(generator.next().value)
+    .toEqual(fork(sagas.watchPostListReadRequest, api))
 })

--- a/src-example/store/resource/sagas.js
+++ b/src-example/store/resource/sagas.js
@@ -1,91 +1,90 @@
 import { take, put, call, fork } from 'redux-saga/effects'
-import api from 'services/api'
 import * as actions from './actions'
 
-export function* createResource(newData) {
+export function* createResource(api, newData) {
   try {
-    const data = yield call(api.post, '/resources', newData)
+    const data = yield call([api, api.post], '/resources', newData)
     yield put(actions.resourceCreateSuccess(data))
   } catch (e) {
     yield put(actions.resourceCreateFailure(e))
   }
 }
 
-export function* readResourceList(params) {
+export function* readResourceList(api, params) {
   try {
-    const data = yield call(api.get, '/resources', { params })
+    const data = yield call([api, api.get], '/resources', { params })
     yield put(actions.resourceListReadSuccess(data))
   } catch (e) {
     yield put(actions.resourceListReadFailure(e))
   }
 }
 
-export function* readResourceDetail(needle) {
+export function* readResourceDetail(api, needle) {
   try {
-    const data = yield call(api.get, `/resources/${needle}`)
+    const data = yield call([api, api.get], `/resources/${needle}`)
     yield put(actions.resourceDetailReadSuccess(needle, data))
   } catch (e) {
     yield put(actions.resourceDetailReadFailure(needle, e))
   }
 }
 
-export function* updateResource(needle, newData) {
+export function* updateResource(api, needle, newData) {
   try {
-    const data = yield call(api.put, `/resources/${needle}`, newData)
+    const data = yield call([api, api.put], `/resources/${needle}`, newData)
     yield put(actions.resourceUpdateSuccess(needle, data))
   } catch (e) {
     yield put(actions.resourceUpdateFailure(needle, e))
   }
 }
 
-export function* deleteResource(needle) {
+export function* deleteResource(api, needle) {
   try {
-    yield call(api.delete, `/resources/${needle}`)
+    yield call([api, api.delete], `/resources/${needle}`)
     yield put(actions.resourceDeleteSuccess(needle))
   } catch (e) {
     yield put(actions.resourceDeleteFailure(needle, e))
   }
 }
 
-export function* watchResourceCreateRequest() {
+export function* watchResourceCreateRequest(api) {
   while (true) {
     const { data } = yield take(actions.RESOURCE_CREATE_REQUEST)
-    yield call(createResource, data)
+    yield call(createResource, api, data)
   }
 }
 
-export function* watchResourceListReadRequest() {
+export function* watchResourceListReadRequest(api) {
   while (true) {
     const { params } = yield take(actions.RESOURCE_LIST_READ_REQUEST)
-    yield call(readResourceList, params)
+    yield call(readResourceList, api, params)
   }
 }
 
-export function* watchResourceDetailReadRequest() {
+export function* watchResourceDetailReadRequest(api) {
   while (true) {
     const { needle } = yield take(actions.RESOURCE_DETAIL_READ_REQUEST)
-    yield call(readResourceDetail, needle)
+    yield call(readResourceDetail, api, needle)
   }
 }
 
-export function* watchResourceUpdateRequest() {
+export function* watchResourceUpdateRequest(api) {
   while (true) {
     const { needle, data } = yield take(actions.RESOURCE_UPDATE_REQUEST)
-    yield call(updateResource, needle, data)
+    yield call(updateResource, api, needle, data)
   }
 }
 
-export function* watchResourceDeleteRequest() {
+export function* watchResourceDeleteRequest(api) {
   while (true) {
     const { needle } = yield take(actions.RESOURCE_DELETE_REQUEST)
-    yield call(deleteResource, needle)
+    yield call(deleteResource, api, needle)
   }
 }
 
-export default function* () {
-  yield fork(watchResourceCreateRequest)
-  yield fork(watchResourceListReadRequest)
-  yield fork(watchResourceDetailReadRequest)
-  yield fork(watchResourceUpdateRequest)
-  yield fork(watchResourceDeleteRequest)
+export default function* ({ api }) {
+  yield fork(watchResourceCreateRequest, api)
+  yield fork(watchResourceListReadRequest, api)
+  yield fork(watchResourceDetailReadRequest, api)
+  yield fork(watchResourceUpdateRequest, api)
+  yield fork(watchResourceDeleteRequest, api)
 }

--- a/src-example/store/resource/sagas.test.js
+++ b/src-example/store/resource/sagas.test.js
@@ -1,123 +1,159 @@
 import { take, put, call, fork } from 'redux-saga/effects'
-import api from 'services/api'
 import * as actions from './actions'
 import saga, * as sagas from './sagas'
+
+const api = {
+  post: () => {},
+  get: () => {},
+  put: () => {},
+  delete: () => {},
+}
 
 describe('createResource', () => {
   const data = { title: 'test' }
 
   it('calls success', () => {
-    const generator = sagas.createResource(data)
-    expect(generator.next().value).toEqual(call(api.post, '/resources', data))
-    expect(generator.next(data).value).toEqual(put(actions.resourceCreateSuccess(data)))
+    const generator = sagas.createResource(api, data)
+    expect(generator.next().value)
+      .toEqual(call([api, api.post], '/resources', data))
+    expect(generator.next(data).value)
+      .toEqual(put(actions.resourceCreateSuccess(data)))
   })
 
   it('calls failure', () => {
-    const generator = sagas.createResource(data)
-    expect(generator.next().value).toEqual(call(api.post, '/resources', data))
-    expect(generator.throw('test').value).toEqual(put(actions.resourceCreateFailure('test')))
+    const generator = sagas.createResource(api, data)
+    expect(generator.next().value)
+      .toEqual(call([api, api.post], '/resources', data))
+    expect(generator.throw('test').value)
+      .toEqual(put(actions.resourceCreateFailure('test')))
   })
 })
 
 describe('readResourceList', () => {
   it('calls success', () => {
     const data = [1, 2, 3]
-    const generator = sagas.readResourceList({ _limit: 1 })
-    expect(generator.next().value).toEqual(call(api.get, '/resources', { params: { _limit: 1 } }))
-    expect(generator.next(data).value).toEqual(put(actions.resourceListReadSuccess(data)))
+    const generator = sagas.readResourceList(api, { _limit: 1 })
+    expect(generator.next().value)
+      .toEqual(call([api, api.get], '/resources', { params: { _limit: 1 } }))
+    expect(generator.next(data).value)
+      .toEqual(put(actions.resourceListReadSuccess(data)))
   })
 
   it('calls failure', () => {
-    const generator = sagas.readResourceList({ _limit: 1 })
-    expect(generator.next().value).toEqual(call(api.get, '/resources', { params: { _limit: 1 } }))
-    expect(generator.throw('test').value).toEqual(put(actions.resourceListReadFailure('test')))
+    const generator = sagas.readResourceList(api, { _limit: 1 })
+    expect(generator.next().value)
+      .toEqual(call([api, api.get], '/resources', { params: { _limit: 1 } }))
+    expect(generator.throw('test').value)
+      .toEqual(put(actions.resourceListReadFailure('test')))
   })
 })
 
 describe('readResourceDetail', () => {
   it('calls success', () => {
     const data = { id: 1 }
-    const generator = sagas.readResourceDetail(1)
-    expect(generator.next().value).toEqual(call(api.get, '/resources/1'))
-    expect(generator.next(data).value).toEqual(put(actions.resourceDetailReadSuccess(1, data)))
+    const generator = sagas.readResourceDetail(api, 1)
+    expect(generator.next().value)
+      .toEqual(call([api, api.get], '/resources/1'))
+    expect(generator.next(data).value)
+      .toEqual(put(actions.resourceDetailReadSuccess(1, data)))
   })
 
   it('calls failure', () => {
-    const generator = sagas.readResourceDetail(1)
-    expect(generator.next().value).toEqual(call(api.get, '/resources/1'))
-    expect(generator.throw('test').value).toEqual(put(actions.resourceDetailReadFailure(1, 'test')))
+    const generator = sagas.readResourceDetail(api, 1)
+    expect(generator.next().value)
+      .toEqual(call([api, api.get], '/resources/1'))
+    expect(generator.throw('test').value)
+      .toEqual(put(actions.resourceDetailReadFailure(1, 'test')))
   })
 })
 
 describe('updateResource', () => {
   it('calls success', () => {
     const data = { id: 1 }
-    const generator = sagas.updateResource(1, { title: 'foo' })
-    expect(generator.next().value).toEqual(call(api.put, '/resources/1', { title: 'foo' }))
-    expect(generator.next(data).value).toEqual(put(actions.resourceUpdateSuccess(1, data)))
+    const generator = sagas.updateResource(api, 1, { title: 'foo' })
+    expect(generator.next().value)
+      .toEqual(call([api, api.put], '/resources/1', { title: 'foo' }))
+    expect(generator.next(data).value)
+      .toEqual(put(actions.resourceUpdateSuccess(1, data)))
   })
 
   it('calls failure', () => {
-    const generator = sagas.updateResource(1, { title: 'foo' })
-    expect(generator.next().value).toEqual(call(api.put, '/resources/1', { title: 'foo' }))
-    expect(generator.throw('test').value).toEqual(put(actions.resourceUpdateFailure(1, 'test')))
+    const generator = sagas.updateResource(api, 1, { title: 'foo' })
+    expect(generator.next().value)
+      .toEqual(call([api, api.put], '/resources/1', { title: 'foo' }))
+    expect(generator.throw('test').value)
+      .toEqual(put(actions.resourceUpdateFailure(1, 'test')))
   })
 })
 
 describe('deleteResource', () => {
   it('calls success', () => {
-    const generator = sagas.deleteResource(1)
-    expect(generator.next().value).toEqual(call(api.delete, '/resources/1'))
-    expect(generator.next().value).toEqual(put(actions.resourceDeleteSuccess(1)))
+    const generator = sagas.deleteResource(api, 1)
+    expect(generator.next().value)
+      .toEqual(call([api, api.delete], '/resources/1'))
+    expect(generator.next().value)
+      .toEqual(put(actions.resourceDeleteSuccess(1)))
   })
 
   it('calls failure', () => {
-    const generator = sagas.deleteResource(1)
-    expect(generator.next().value).toEqual(call(api.delete, '/resources/1'))
-    expect(generator.throw('test').value).toEqual(put(actions.resourceDeleteFailure(1, 'test')))
+    const generator = sagas.deleteResource(api, 1)
+    expect(generator.next().value)
+      .toEqual(call([api, api.delete], '/resources/1'))
+    expect(generator.throw('test').value)
+      .toEqual(put(actions.resourceDeleteFailure(1, 'test')))
   })
 })
 
 test('watchResourceCreateRequest', () => {
   const payload = { data: 1 }
-  const generator = sagas.watchResourceCreateRequest()
-  expect(generator.next().value).toEqual(take(actions.RESOURCE_CREATE_REQUEST))
-  expect(generator.next(payload).value).toEqual(call(sagas.createResource, ...Object.values(payload)))
+  const generator = sagas.watchResourceCreateRequest(api)
+  expect(generator.next().value)
+    .toEqual(take(actions.RESOURCE_CREATE_REQUEST))
+  expect(generator.next(payload).value)
+    .toEqual(call(sagas.createResource, api, ...Object.values(payload)))
 })
 
 test('watchResourceListReadRequest', () => {
   const payload = { params: { _limit: 1 } }
-  const generator = sagas.watchResourceListReadRequest()
-  expect(generator.next().value).toEqual(take(actions.RESOURCE_LIST_READ_REQUEST))
-  expect(generator.next(payload).value).toEqual(call(sagas.readResourceList, ...Object.values(payload)))
+  const generator = sagas.watchResourceListReadRequest(api)
+  expect(generator.next().value)
+    .toEqual(take(actions.RESOURCE_LIST_READ_REQUEST))
+  expect(generator.next(payload).value)
+    .toEqual(call(sagas.readResourceList, api, ...Object.values(payload)))
 })
 
 test('watchResourceDetailReadRequest', () => {
   const payload = { needle: 1 }
-  const generator = sagas.watchResourceDetailReadRequest()
-  expect(generator.next().value).toEqual(take(actions.RESOURCE_DETAIL_READ_REQUEST))
-  expect(generator.next(payload).value).toEqual(call(sagas.readResourceDetail, ...Object.values(payload)))
+  const generator = sagas.watchResourceDetailReadRequest(api)
+  expect(generator.next().value)
+    .toEqual(take(actions.RESOURCE_DETAIL_READ_REQUEST))
+  expect(generator.next(payload).value)
+    .toEqual(call(sagas.readResourceDetail, api, ...Object.values(payload)))
 })
 
 test('watchResourceUpdateRequest', () => {
   const payload = { needle: 1, data: { id: 1 } }
-  const generator = sagas.watchResourceUpdateRequest()
-  expect(generator.next().value).toEqual(take(actions.RESOURCE_UPDATE_REQUEST))
-  expect(generator.next(payload).value).toEqual(call(sagas.updateResource, ...Object.values(payload)))
+  const generator = sagas.watchResourceUpdateRequest(api)
+  expect(generator.next().value)
+    .toEqual(take(actions.RESOURCE_UPDATE_REQUEST))
+  expect(generator.next(payload).value)
+    .toEqual(call(sagas.updateResource, api, ...Object.values(payload)))
 })
 
 test('watchResourceDeleteRequest', () => {
   const payload = { needle: 1 }
-  const generator = sagas.watchResourceDeleteRequest()
-  expect(generator.next().value).toEqual(take(actions.RESOURCE_DELETE_REQUEST))
-  expect(generator.next(payload).value).toEqual(call(sagas.deleteResource, ...Object.values(payload)))
+  const generator = sagas.watchResourceDeleteRequest(api)
+  expect(generator.next().value)
+    .toEqual(take(actions.RESOURCE_DELETE_REQUEST))
+  expect(generator.next(payload).value)
+    .toEqual(call(sagas.deleteResource, api, ...Object.values(payload)))
 })
 
 test('saga', () => {
-  const generator = saga()
-  expect(generator.next().value).toEqual(fork(sagas.watchResourceCreateRequest))
-  expect(generator.next().value).toEqual(fork(sagas.watchResourceListReadRequest))
-  expect(generator.next().value).toEqual(fork(sagas.watchResourceDetailReadRequest))
-  expect(generator.next().value).toEqual(fork(sagas.watchResourceUpdateRequest))
-  expect(generator.next().value).toEqual(fork(sagas.watchResourceDeleteRequest))
+  const generator = saga({ api })
+  expect(generator.next().value).toEqual(fork(sagas.watchResourceCreateRequest, api))
+  expect(generator.next().value).toEqual(fork(sagas.watchResourceListReadRequest, api))
+  expect(generator.next().value).toEqual(fork(sagas.watchResourceDetailReadRequest, api))
+  expect(generator.next().value).toEqual(fork(sagas.watchResourceUpdateRequest, api))
+  expect(generator.next().value).toEqual(fork(sagas.watchResourceDeleteRequest, api))
 })

--- a/src-example/store/sagas.js
+++ b/src-example/store/sagas.js
@@ -8,6 +8,6 @@ req.keys().forEach((key) => {
   sagas.push(req(key).default)
 })
 
-export default function* () {
-  yield sagas.map(fork)
+export default function* (services = {}) {
+  yield sagas.map(saga => fork(saga, services))
 }

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,8 @@ const merge = require('lodash/merge')
 const config = {
   all: {
     env: process.env.NODE_ENV || 'development',
+    isDev: process.env.NODE_ENV !== 'production',
+    isBrowser: typeof window !== 'undefined',
     apiUrl: 'https://jsonplaceholder.typicode.com',
   },
   test: {},

--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,11 @@ import { createHistory } from 'history'
 import { Router, useRouterHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
 import configureStore from 'store/configure'
-
+import api from 'services/api'
 import routes from 'routes'
 
 const baseHistory = useRouterHistory(createHistory)({ basename: process.env.PUBLIC_PATH })
-const store = configureStore({}, baseHistory)
+const store = configureStore({}, baseHistory, { api: api.create() })
 const history = syncHistoryWithStore(baseHistory, store)
 const root = document.getElementById('app')
 

--- a/src/store/configure.js
+++ b/src/store/configure.js
@@ -1,21 +1,28 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import { routerMiddleware } from 'react-router-redux'
 import createSagaMiddleware from 'redux-saga'
+import { isDev, isBrowser } from 'config'
 import middlewares from './middlewares'
 import reducer from './reducer'
 import sagas from './sagas'
 
-const configureStore = (initialState, history) => {
-  const hasWindow = typeof window !== 'undefined'
-  const sagaMiddleware = createSagaMiddleware()
+const devtools = isDev && isBrowser && window.devToolsExtension
+  ? window.devToolsExtension
+  : () => fn => fn
+const sagaMiddleware = createSagaMiddleware()
 
-  const finalCreateStore = compose(
-    applyMiddleware(...middlewares, sagaMiddleware, routerMiddleware(history)),
-    hasWindow && window.devToolsExtension ? window.devToolsExtension() : (f) => f
-  )(createStore)
+const configureStore = (initialState, history, services = {}) => {
+  const enhancers = [
+    applyMiddleware(
+      ...middlewares,
+      sagaMiddleware,
+      routerMiddleware(history)
+    ),
+    devtools(),
+  ]
 
-  const store = finalCreateStore(reducer, initialState)
-  let sagaTask = sagaMiddleware.run(sagas)
+  const store = createStore(reducer, initialState, compose(...enhancers))
+  let sagaTask = sagaMiddleware.run(sagas, services)
 
   if (module.hot) {
     module.hot.accept('./reducer', () => {
@@ -26,7 +33,7 @@ const configureStore = (initialState, history) => {
       const nextSagas = require('./sagas').default
       sagaTask.cancel()
       sagaTask.done.then(() => {
-        sagaTask = sagaMiddleware.run(nextSagas)
+        sagaTask = sagaMiddleware.run(nextSagas, services)
       })
     })
   }

--- a/src/store/sagas.js
+++ b/src/store/sagas.js
@@ -8,6 +8,6 @@ req.keys().forEach((key) => {
   sagas.push(req(key).default)
 })
 
-export default function* () {
-  yield sagas.map(fork)
+export default function* (services = {}) {
+  yield sagas.map(saga => fork(saga, services))
 }


### PR DESCRIPTION
It passes an API instance down to sagas so we can use `api.setToken`.