### PR TITLE
[redux] Remove react-router-redux

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,15 +2,13 @@
 import React from 'react'
 import { configure, addDecorator } from '@kadira/storybook'
 import { Provider } from 'react-redux'
-import { ConnectedRouter } from 'react-router-redux'
-import createHistory from 'history/createBrowserHistory'
+import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import configureStore from 'store/configure'
 import api from 'services/api'
 import theme from 'components/themes/default'
 
-const history = createHistory()
-const store = configureStore({}, history, { api: api.create() })
+const store = configureStore({}, { api: api.create() })
 const req = require.context('components', true, /.stories.js$/)
 
 function loadStories() {
@@ -19,9 +17,9 @@ function loadStories() {
 
 addDecorator(story => (
   <Provider store={store}>
-    <ConnectedRouter history={history}>
+    <BrowserRouter>
       <ThemeProvider theme={theme}>{story()}</ThemeProvider>
-    </ConnectedRouter>
+    </BrowserRouter>
   </Provider>
 ))
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "react-modal": "^1.6.5",
     "react-redux": "^5.0.1",
     "react-router-dom": "^4.1.1",
-    "react-router-redux": "5.0.0-alpha.6",
     "redux": "^3.6.0",
     "redux-form": "^6.4.3",
     "redux-saga": "^0.14.1",

--- a/src-example/index.js
+++ b/src-example/index.js
@@ -4,22 +4,20 @@ import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
-import { ConnectedRouter } from 'react-router-redux'
-import createHistory from 'history/createBrowserHistory'
+import { BrowserRouter } from 'react-router-dom'
 
 import { basename } from 'config'
 import configureStore from 'store/configure'
 import api from 'services/api'
 import App from 'components/App'
 
-const history = createHistory({ basename })
-const store = configureStore({}, history, { api: api.create() })
+const store = configureStore({}, { api: api.create() })
 
 const renderApp = () => (
   <Provider store={store}>
-    <ConnectedRouter history={history}>
+    <BrowserRouter basename={basename}>
       <App />
-    </ConnectedRouter>
+    </BrowserRouter>
   </Provider>
 )
 

--- a/src-example/store/configure.js
+++ b/src-example/store/configure.js
@@ -1,6 +1,5 @@
 // https://github.com/diegohaz/arc/wiki/Redux-modules
 import { createStore, applyMiddleware, compose } from 'redux'
-import { routerMiddleware } from 'react-router-redux'
 import createSagaMiddleware from 'redux-saga'
 import { isDev, isBrowser } from 'config'
 import middlewares from './middlewares'
@@ -11,14 +10,13 @@ const devtools = isDev && isBrowser && window.devToolsExtension
   ? window.devToolsExtension
   : () => fn => fn
 
-const configureStore = (initialState, history, services = {}) => {
+const configureStore = (initialState, services = {}) => {
   const sagaMiddleware = createSagaMiddleware()
 
   const enhancers = [
     applyMiddleware(
       ...middlewares,
-      sagaMiddleware,
-      routerMiddleware(history)
+      sagaMiddleware
     ),
     devtools(),
   ]

--- a/src-example/store/reducer.js
+++ b/src-example/store/reducer.js
@@ -1,11 +1,9 @@
 // https://github.com/diegohaz/arc/wiki/Reducers
 import camelCase from 'lodash/camelCase'
 import { combineReducers } from 'redux'
-import { routerReducer as router } from 'react-router-redux'
 import { reducer as form } from 'redux-form'
 
 const reducers = {
-  router,
   form,
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,22 +4,20 @@ import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
-import { ConnectedRouter } from 'react-router-redux'
-import createHistory from 'history/createBrowserHistory'
+import { BrowserRouter } from 'react-router-dom'
 
 import { basename } from 'config'
 import configureStore from 'store/configure'
 import api from 'services/api'
 import App from 'components/App'
 
-const history = createHistory({ basename })
-const store = configureStore({}, history, { api: api.create() })
+const store = configureStore({}, { api: api.create() })
 
 const renderApp = () => (
   <Provider store={store}>
-    <ConnectedRouter history={history}>
+    <BrowserRouter basename={basename}>
       <App />
-    </ConnectedRouter>
+    </BrowserRouter>
   </Provider>
 )
 

--- a/src/store/configure.js
+++ b/src/store/configure.js
@@ -1,6 +1,5 @@
 // https://github.com/diegohaz/arc/wiki/Redux-modules
 import { createStore, applyMiddleware, compose } from 'redux'
-import { routerMiddleware } from 'react-router-redux'
 import createSagaMiddleware from 'redux-saga'
 import { isDev, isBrowser } from 'config'
 import middlewares from './middlewares'
@@ -11,14 +10,13 @@ const devtools = isDev && isBrowser && window.devToolsExtension
   ? window.devToolsExtension
   : () => fn => fn
 
-const configureStore = (initialState, history, services = {}) => {
+const configureStore = (initialState, services = {}) => {
   const sagaMiddleware = createSagaMiddleware()
 
   const enhancers = [
     applyMiddleware(
       ...middlewares,
-      sagaMiddleware,
-      routerMiddleware(history)
+      sagaMiddleware
     ),
     devtools(),
   ]

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -1,11 +1,9 @@
 // https://github.com/diegohaz/arc/wiki/Reducers
 import camelCase from 'lodash/camelCase'
 import { combineReducers } from 'redux'
-import { routerReducer as router } from 'react-router-redux'
 import { reducer as form } from 'redux-form'
 
 const reducers = {
-  router,
   form,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,14 +5614,6 @@ react-router-dom@^4.1.1:
     prop-types "^15.5.4"
     react-router "^4.1.1"
 
-react-router-redux@5.0.0-alpha.6:
-  version "5.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.6.tgz#7418663c2ecd3c51be856fcf28f3d1deecc1a576"
-  dependencies:
-    history "^4.5.1"
-    prop-types "^15.5.4"
-    react-router "^4.1.1"
-
 react-router@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.1.1.tgz#d448f3b7c1b429a6fbb03395099949c606b1fe95"
@@ -6353,17 +6345,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-style-loader@0.13.1:
+style-loader@0.13.1, style-loader@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.13.1.tgz#468280efbc0473023cd3a6cd56e33b5a1d7fc3a9"
   dependencies:
     loader-utils "^0.2.7"
-
-style-loader@^0.13.1:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.13.2.tgz#74533384cf698c7104c7951150b49717adc2f3bb"
-  dependencies:
-    loader-utils "^1.0.2"
 
 styled-components@^1.4.4:
   version "1.4.5"


### PR DESCRIPTION
`react-router-redux` is still in alpha and still has a lot of things to implement. SSR integration is inconsistent and time travel through `redux-devtools` still doesn't work.

We can just pass the `history` object to actions and receive it on sagas to do the same thing.