### PR TITLE
[Redux] #264 API settings parser merges additional settings

### DIFF
--- a/src-example/services/api/index.js
+++ b/src-example/services/api/index.js
@@ -21,12 +21,11 @@ export const parseSettings = ({ method = 'get', data, locale, ...otherSettings }
     'Content-Type': 'application/json',
     'Accept-Language': locale,
   }
-  const settings = {
+  const settings = merge({
     body: data ? JSON.stringify(data) : undefined,
     method,
     headers,
-    ...otherSettings,
-  }
+  }, otherSettings)
   return settings
 }
 

--- a/src-example/services/api/index.test.js
+++ b/src-example/services/api/index.test.js
@@ -44,7 +44,7 @@ describe('parseSettings', () => {
   })
 
   it('merges headers', () => {
-    const otherSettings = { headers: { foo: 'bar' }}
+    const otherSettings = { headers: { foo: 'bar' } }
     const settings = parseSettings(otherSettings)
     expect(settings).toHaveProperty('headers.foo', 'bar')
     expect(Object.keys(settings.headers).length)

--- a/src-example/services/api/index.test.js
+++ b/src-example/services/api/index.test.js
@@ -42,6 +42,14 @@ describe('parseSettings', () => {
   it('has passed method', () => {
     expect(parseSettings({ method: 'post' }).method).toBe('post')
   })
+
+  it('merges headers', () => {
+    const otherSettings = { headers: { foo: 'bar' }}
+    const settings = parseSettings(otherSettings)
+    expect(settings).toHaveProperty('headers.foo', 'bar')
+    expect(Object.keys(settings.headers).length)
+      .toBeGreaterThan(Object.keys(otherSettings.headers).length)
+  })
 })
 
 describe('parseEndpoint', () => {


### PR DESCRIPTION
If header fields are passed into `parseSettings` they'll overwrite the default headers completely. This pull request fixes issue #264. It merges new settings/headers to the default ones.