### PR TITLE
[redux-ssr] Resolves Warning: Accessing PropTypes

### DIFF
--- a/src-example/components/Html.js
+++ b/src-example/components/Html.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 
 const Html = ({ styles, assets, state, content }) => {

--- a/src/components/Html.js
+++ b/src/components/Html.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 
 const Html = ({ styles, assets, state, content }) => {


### PR DESCRIPTION
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs