### PR TITLE
Improved resolution of circularly dependent components (#130)

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,23 @@
+const merge = require('lodash/merge')
+
 // https://github.com/diegohaz/arc/wiki/Atomic-Design#do-not-worry
 const req = require.context('.', true, /\.\/[^/]+\/[^/]+\/index\.js$/)
 
+
+// This exports all components, resolving circular dependencies in two steps:
+// 1. export empty objects in place of each component
+// 2. require each component and merge it into the existing export for that module
+
+const componentPaths = []
+
+// export an empty module for each component
 req.keys().forEach((key) => {
   const componentName = key.replace(/^.+\/([^/]+)\/index\.js/, '$1')
-  module.exports[componentName] = req(key).default
+  componentPaths.push({ componentName, key })
+  module.exports[componentName] = {}
+})
+
+// merge each component into its designated module
+componentPaths.forEach(({ componentName, key }) => {
+  merge(module.exports[componentName], req(key).default)
 })


### PR DESCRIPTION
### What
Improved how circularly dependent components are resolved by adopting webpack's resolution methodology: export empty modules first (as placeholders), then reiterate and actually export each module.

### Why
This allows modules to hold references to their dependencies before they actually get exported :)

### Caveats
as [mentioned in #130](https://github.com/diegohaz/arc/issues/130#issuecomment-328640586) this still does *not* solve the `styled(CircularDependentComponent)` problem, BUT it does allow circularly dependent components to properly reference each other and work properly as long as evaluation doesn't occur until after the exports are fully resolved (i.e not having immediately invoked functions requiring dependent components).