### PR TITLE
fully automate the dev setup with Gitpod.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: yarn install && yarn run build
+    command: yarn run start
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <a href="https://travis-ci.org/diegohaz/arc"><img src="https://img.shields.io/travis/diegohaz/arc/master.svg?style=flat-square" alt="Build Status" /></a>
   <a href="https://codecov.io/gh/diegohaz/arc"><img src="https://img.shields.io/codecov/c/github/diegohaz/arc.svg?style=flat-square" alt="Coverage Status" /></a>
   <a href="https://gitter.im/diegohaz/arc"><img src="https://img.shields.io/badge/chat-on%20gitter-1dce73.svg?style=flat-square" alt="Gitter chat" /></a>
+  <a href="https://gitpod.io/#https://github.com/diegohaz/arc"><img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"></a>
 </p>
 
 **ARc** (Atomic React) is a React starter kit based on the [Atomic Design](http://bradfrost.com/blog/post/atomic-web-design/) methodology. It's progressive, which means that you can start with the basic boilerplate and try the other features when you are comfortable.
@@ -43,6 +44,16 @@ I had a React project with more than 100 components in the `components` folder. 
 The [Atomic Design](http://bradfrost.com/blog/post/atomic-web-design/) approach comes handy to solve this problem because it considers the reusability through composition, *which is actually what React is*. You will have your minimal/stylish components in one folder, pages in another and so on.
 
 ## Setup
+
+### Online one-click setup
+
+You can use Gitpod (a free online VS Code-like IDE) for the one-click setup. With a single click it'll launch a workspace and automatically:
+
+- clone the arc repo.
+- install the dependencies.
+- run `yarn run start`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ### 1. Get the source code
 


### PR DESCRIPTION
This Pr simplifies code contributions by fully automating the dev setup with Gitpod (a free online VS Code-like IDE). With a single click, it'll launch a workspace and automatically:

- clone the arc repo.
- install the dependencies.
-  run `yarn run start`.

So that anyone interested in contributing can start straight away.

You can give it a try it on my fork via this link:

https://gitpod.io/#https://github.com/nisarhassan12/arc

![image](https://user-images.githubusercontent.com/46004116/74626515-b2bb6000-5171-11ea-88e6-c75408868709.png)
